### PR TITLE
Fix PathTracker Concurrency Bug and Hide Transaction Object

### DIFF
--- a/concurrent_maps/AVLHTM/include/avl.hpp
+++ b/concurrent_maps/AVLHTM/include/avl.hpp
@@ -418,11 +418,9 @@ class AVLTree {
         // the insert operation
         bool insert_impl(const int k, ValueType val, int t_id) {
 
-            int retries = trans_retries;
+            (void)t_id;
             
-            TM_SAFE_OPERATION_START {
-
-                TSX::Transaction t(retries,_lock, stats[t_id]);
+            TM_SAFE_OPERATION_START(30) {
 
                 /* FIND PHASE */
 
@@ -437,7 +435,7 @@ class AVLTree {
 
                     /* FIND PHASE END */
 
-                ConnPoint<TreeNode> conn(conn_point_snapshot, t);
+                ConnPoint<TreeNode> conn(conn_point_snapshot);
 
                 /* INSERT */
 
@@ -534,11 +532,9 @@ class AVLTree {
 
 
     bool remove_impl(const int k, const int t_id) {
+        (void)t_id;
         
-        int retries = trans_retries;
-
-        TM_SAFE_OPERATION_START {
-            TSX::Transaction t(retries,_lock, stats[t_id]);
+        TM_SAFE_OPERATION_START(30) {
 
             /* FIND PHASE */
 
@@ -553,7 +549,7 @@ class AVLTree {
 
             /* FIND PHASE END */
 
-            ConnPoint<TreeNode> conn(conn_point_snapshot, t);
+            ConnPoint<TreeNode> conn(conn_point_snapshot);
 
             /* REMOVE */
 

--- a/concurrent_maps/AVLHTM/tests/avl_test.cpp
+++ b/concurrent_maps/AVLHTM/tests/avl_test.cpp
@@ -298,7 +298,7 @@ TEST_CASE("THROUGHPUT TESTS","[tp]") {
         std::cout << "Start of tests for tree size: " << OPERATION_MULTIPLIERS[i] << std::endl;
         const std::size_t RANGE_OF_KEYS = 2 * OPERATION_MULTIPLIERS[i]; // RANGE IS 1 TO RANGE_OF_KEYS
 
-        std::vector<int> threads_to_use = {1};
+        std::vector<int> threads_to_use = {1,2,4,7,14,20,28};
         // RANDOM OPS
         TestBenchType::experiment exp1(33,33,34);
         TestBenchType::test(exp1,THREADS,RANGE_OF_KEYS,threads_to_use);

--- a/concurrent_maps/AVLHTM/tests/avl_test.cpp
+++ b/concurrent_maps/AVLHTM/tests/avl_test.cpp
@@ -292,13 +292,13 @@ TEST_CASE("AVLTree MULTITHREADED Remove Test","[remove_mt]") {
 
 
 TEST_CASE("THROUGHPUT TESTS","[tp]") {
-    const int OPERATION_MULTIPLIERS[] = {1000000,10000,1000};
+    const int OPERATION_MULTIPLIERS[] = {1000};
 
     for (int i = 0; i < 4; i++) {
         std::cout << "Start of tests for tree size: " << OPERATION_MULTIPLIERS[i] << std::endl;
         const std::size_t RANGE_OF_KEYS = 2 * OPERATION_MULTIPLIERS[i]; // RANGE IS 1 TO RANGE_OF_KEYS
 
-        std::vector<int> threads_to_use = {1,2,4,7,14,20,28};
+        std::vector<int> threads_to_use = {1};
         // RANDOM OPS
         TestBenchType::experiment exp1(33,33,34);
         TestBenchType::test(exp1,THREADS,RANGE_OF_KEYS,threads_to_use);

--- a/concurrent_maps/AVLHTMGeneric/include/avl.hpp
+++ b/concurrent_maps/AVLHTMGeneric/include/avl.hpp
@@ -416,12 +416,9 @@ class AVLTree {
         }
 
         bool insert_impl(const int k, ValueType val, int t_id) {
-
-            int retries = trans_retries;
+            (void)t_id;
             
-            TM_SAFE_OPERATION_START {
-
-                TSX::Transaction t(retries,_lock, stats[t_id]);
+            TM_SAFE_OPERATION_START(30) {
 
                 /* FIND PHASE */
 
@@ -437,7 +434,7 @@ class AVLTree {
 
                 /* FIND PHASE END */
 
-                ConnPoint<TreeNode> conn(conn_point_snapshot, t);
+                ConnPoint<TreeNode> conn(conn_point_snapshot);
 
                 /* INSERT */
 
@@ -527,10 +524,9 @@ class AVLTree {
 
     bool remove_impl(const int k, const int t_id) {
         
-        int retries = trans_retries;
+        (void)t_id;
 
-        TM_SAFE_OPERATION_START {
-            TSX::Transaction t(retries,_lock, stats[t_id]);
+        TM_SAFE_OPERATION_START(30) {
 
             /* FIND PHASE */
 
@@ -546,7 +542,7 @@ class AVLTree {
 
             /* FIND PHASE END */
 
-            ConnPoint<TreeNode> conn(conn_point_snapshot, t);
+            ConnPoint<TreeNode> conn(conn_point_snapshot);
 
             /* REMOVE */
 

--- a/concurrent_maps/AVLHTMGeneric/tests/Makefile
+++ b/concurrent_maps/AVLHTMGeneric/tests/Makefile
@@ -1,5 +1,5 @@
 CC=clang++
-CFLAGS=-std=c++0x -static -pthread -O3 -Wall -Werror -Wextra -DCATCH_CONFIG_ENABLE_BENCHMARKING -Wl,--whole-archive -lpthread -Wl,--no-whole-archive
+CFLAGS=-std=c++0x -static -pthread -O3 -g -Wall -Werror -Wextra -DCATCH_CONFIG_ENABLE_BENCHMARKING -Wl,--whole-archive -lpthread -Wl,--no-whole-archive
 CFLAGSSIMPLE=-std=c++0x -static -pthread -Og -g -Wall -Werror -Wextra -DCATCH_CONFIG_ENABLE_BENCHMARKING
 URCU_REQS = ../obj/urcu.o
 

--- a/concurrent_maps/AVLHTMGeneric/tests/avl_generic_test.cpp
+++ b/concurrent_maps/AVLHTMGeneric/tests/avl_generic_test.cpp
@@ -270,13 +270,13 @@ TEST_CASE("AVLTree MULTITHREADED Remove Test","[remove_mt]") {
 
 
 TEST_CASE("THROUGHPUT TESTS","[tp]") {
-    const int OPERATION_MULTIPLIERS[] = {1000000,10000,1000};
+    const int OPERATION_MULTIPLIERS[] = {1000, 10000, 1000000};
 
     for (int i = 0; i < 4; i++) {
         std::cout << "Start of tests for tree size: " << OPERATION_MULTIPLIERS[i] << std::endl;
         const std::size_t RANGE_OF_KEYS = 2 * OPERATION_MULTIPLIERS[i]; // RANGE IS 1 TO RANGE_OF_KEYS
 
-        std::vector<int> threads_to_use = {1,2,4,7,14,20,28};
+        std::vector<int> threads_to_use = {6};//,2,4,7,14,20,28};
         // RANDOM OPS
         TestBenchType::experiment exp1(33,33,34);
         TestBenchType::test(exp1,THREADS,RANGE_OF_KEYS,threads_to_use);

--- a/concurrent_maps/AVLHTMGeneric/tests/avl_generic_test.cpp
+++ b/concurrent_maps/AVLHTMGeneric/tests/avl_generic_test.cpp
@@ -276,7 +276,7 @@ TEST_CASE("THROUGHPUT TESTS","[tp]") {
         std::cout << "Start of tests for tree size: " << OPERATION_MULTIPLIERS[i] << std::endl;
         const std::size_t RANGE_OF_KEYS = 2 * OPERATION_MULTIPLIERS[i]; // RANGE IS 1 TO RANGE_OF_KEYS
 
-        std::vector<int> threads_to_use = {6};//,2,4,7,14,20,28};
+        std::vector<int> threads_to_use = {1,2,4,7,14,20,28};
         // RANDOM OPS
         TestBenchType::experiment exp1(33,33,34);
         TestBenchType::test(exp1,THREADS,RANGE_OF_KEYS,threads_to_use);

--- a/include/SafeTree.hpp
+++ b/include/SafeTree.hpp
@@ -180,9 +180,8 @@ namespace SafeTree {
                     conn_point_snapshot.con_ptr.child_index = at_root? INSERT_POSITIONS::AT_ROOT : conn_point_and_next_child.next_child;
                     conn_point_snapshot.con_ptr.snapshot = current_pos_;
 
-                    // std::cerr << "Inserting at root?: " << at_root << " con_ptr: " <<  conn_point_and_next_child.node << std::endl;
-                    // std::cerr << "current root:" << *root_ << " con_ptr: " <<  conn_point_snapshot.con_ptr.snapshot << std::endl;
-                    // std::cerr << conn_point_snapshot.connection_point_ << std::endl;
+                    // restore state
+                    path_.push(conn_point_and_next_child.node, conn_point_and_next_child.next_child);
 
 
                     return conn_point_snapshot;
@@ -760,10 +759,6 @@ namespace SafeTree {
                         return false;
                     }
                     
-                    // std::cerr << "actual path" << std::endl;
-                    // std::cerr << "root: " << to_be_validated << std::endl;
-
-                
 
 
                     // do the same for the rest of the path to the conn_point
@@ -771,7 +766,6 @@ namespace SafeTree {
 
                     for (int i = 1; i < path_to_conn_point_.size(); ++i) {
 
-                       // std::cerr << "-> " << supposed_next_child << std::endl;
                         
                         if (path_to_conn_point_[i].node != supposed_next_child) {
                             return false;
@@ -780,13 +774,6 @@ namespace SafeTree {
                         to_be_validated = supposed_next_child;
                         supposed_next_child = to_be_validated->getChild(path_to_conn_point_[i].next_child);
                     }
-
-
-                    // std::cerr << "-> " << supposed_next_child << std::endl;
-
-                    // std::cerr << "stored path" << std::endl;
-                    // path_to_conn_point_.print_contents();
-                    // std::cerr << connection_point_ << std::endl;
 
 
                     // the last node of the path should be the connection point 
@@ -884,7 +871,6 @@ namespace SafeTree {
                         return false;
                     }
                 } else { 
-                    //std::cerr << "non root check" << std::endl;
                     // has the connection pointer to be modified
                     // changed?
                     if (conn_pointer_snapshot_ != connection_point_->getChild(child_to_exchange_)) {
@@ -1195,8 +1181,6 @@ namespace SafeTree {
                     auto parent_of_conn_point = path_to_conn_point_.pop();
                     new_conn_point = parent_of_conn_point.node;
                     new_conn_point_next_index = parent_of_conn_point.next_child;
-                    // std::cerr << "Old conn point: " << connection_point_ << std::endl;
-                    // std::cerr << "Popping: " << new_conn_point << std::endl;
                 }
 
                 // keep old conn pointer snapshot to force its validation

--- a/include/SafeTree.hpp
+++ b/include/SafeTree.hpp
@@ -933,7 +933,7 @@ namespace SafeTree {
             ConnPoint& operator=(const ConnPoint&) = delete;
             ConnPoint(const ConnPoint&) = delete;
 
-            ConnPoint(ConnPointData<NodeType>& data, TSX::Transaction& t):
+            ConnPoint(ConnPointData<NodeType>& data):
             connect_success_(__internal__thread_transaction_success_flag__),
             connection_point_(data.connection_point_), connection_pointer_(nullptr),
             root_(data.root_of_structure),
@@ -941,12 +941,12 @@ namespace SafeTree {
             child_to_exchange_(data.con_ptr.child_index),
             path_to_conn_point_(data.path), 
             copy_connected_(false),
-            _lock(t.get_lock()),
-            stats_(t.get_stats()),
+            _lock(TSX::__internal__trans_pointer->get_lock()),
+            stats_(TSX::__internal__trans_pointer->get_stats()),
             head_(nullptr),
             tree_was_modified_(false),
-            already_locked_(t.has_locked()),
-            trans_retries_(t.get_retries()),
+            already_locked_(TSX::__internal__trans_pointer->has_locked()),
+            trans_retries_(TSX::__internal__trans_pointer->get_retries()),
             validation_aborted_(false)
             {
                 #ifdef TSX_MEM_POOL

--- a/include/SafeTree.hpp
+++ b/include/SafeTree.hpp
@@ -162,9 +162,14 @@ namespace SafeTree {
                 // of copies to be constructed.
                 ConnPointData<NodeType> connectHere() {
 
+                    //path_check();
+
                     ConnPointData<NodeType> conn_point_snapshot;
 
+                    //path_.print_contents();
+
                     bool at_root = at_level_ == -1;
+
                     NodeAndNextPointer<NodeType> conn_point_and_next_child = path_.pop();
                     conn_point_snapshot.connection_point_ = at_root ? nullptr: conn_point_and_next_child.node;
 
@@ -172,8 +177,12 @@ namespace SafeTree {
 
                     conn_point_snapshot.root_of_structure = root_;
 
-                    conn_point_snapshot.con_ptr.child_index = at_root? INSERT_POSITIONS::AT_ROOT :  conn_point_and_next_child.next_child;
+                    conn_point_snapshot.con_ptr.child_index = at_root? INSERT_POSITIONS::AT_ROOT : conn_point_and_next_child.next_child;
                     conn_point_snapshot.con_ptr.snapshot = current_pos_;
+
+                    // std::cerr << "Inserting at root?: " << at_root << " con_ptr: " <<  conn_point_and_next_child.node << std::endl;
+                    // std::cerr << "current root:" << *root_ << " con_ptr: " <<  conn_point_snapshot.con_ptr.snapshot << std::endl;
+                    // std::cerr << conn_point_snapshot.connection_point_ << std::endl;
 
 
                     return conn_point_snapshot;
@@ -731,22 +740,28 @@ namespace SafeTree {
                 // chech if path to connPoint hasn't changed
                 // and if conn_point exists in the tree
                 bool path_unchanged() {
+                    // std::cout << "Path recorded" << std::endl;
+                    // path_to_conn_point_.print_contents();
 
+                    
+                    auto to_be_validated = *root_;
                     
                     // modifying at root?
                     if (path_to_conn_point_.Empty()) {
-                        return true;
+                        return connection_point_ == to_be_validated;
                     }
 
                     // root is unchanged?
                     auto supposed_root = path_to_conn_point_.bottom();
 
-                    auto to_be_validated = *root_;
                     auto next_child = supposed_root.next_child;
 
                     if (supposed_root.node != to_be_validated) {
                         return false;
                     }
+                    
+                    // std::cerr << "actual path" << std::endl;
+                    // std::cerr << "root: " << to_be_validated << std::endl;
 
                 
 
@@ -755,6 +770,8 @@ namespace SafeTree {
                     NodeType* supposed_next_child = supposed_root.node->getChild(next_child);
 
                     for (int i = 1; i < path_to_conn_point_.size(); ++i) {
+
+                       // std::cerr << "-> " << supposed_next_child << std::endl;
                         
                         if (path_to_conn_point_[i].node != supposed_next_child) {
                             return false;
@@ -763,6 +780,13 @@ namespace SafeTree {
                         to_be_validated = supposed_next_child;
                         supposed_next_child = to_be_validated->getChild(path_to_conn_point_[i].next_child);
                     }
+
+
+                    // std::cerr << "-> " << supposed_next_child << std::endl;
+
+                    // std::cerr << "stored path" << std::endl;
+                    // path_to_conn_point_.print_contents();
+                    // std::cerr << connection_point_ << std::endl;
 
 
                     // the last node of the path should be the connection point 
@@ -853,15 +877,14 @@ namespace SafeTree {
             // on failure
             bool validate_copy() {
                 if (!connection_point_) {
-
                     // insertion at root
-
                     // has root copy changed ?
                     if (conn_pointer_snapshot_ != *root_) {
                         TSX::TSXGuard::abort<VALIDATION_FAILED>();
                         return false;
                     }
                 } else { 
+                    //std::cerr << "non root check" << std::endl;
                     // has the connection pointer to be modified
                     // changed?
                     if (conn_pointer_snapshot_ != connection_point_->getChild(child_to_exchange_)) {
@@ -1172,6 +1195,8 @@ namespace SafeTree {
                     auto parent_of_conn_point = path_to_conn_point_.pop();
                     new_conn_point = parent_of_conn_point.node;
                     new_conn_point_next_index = parent_of_conn_point.next_child;
+                    // std::cerr << "Old conn point: " << connection_point_ << std::endl;
+                    // std::cerr << "Popping: " << new_conn_point << std::endl;
                 }
 
                 // keep old conn pointer snapshot to force its validation
@@ -1353,6 +1378,8 @@ namespace SafeTree {
         }
 
     #endif
+
+    
 
         
     }

--- a/include/TSXGuard.hpp
+++ b/include/TSXGuard.hpp
@@ -516,7 +516,7 @@ namespace TSX {
         
     };
 
-    thread_local SpinLock __internal__global_lock;
+    static SpinLock __internal__global_lock;
     thread_local TSXStats __internal__trans_stats;
 
 

--- a/include/TSXGuard.hpp
+++ b/include/TSXGuard.hpp
@@ -516,6 +516,10 @@ namespace TSX {
         
     };
 
+    thread_local SpinLock __internal__global_lock;
+    thread_local TSXStats __internal__trans_stats;
+
+
     // Handles the fallback and retries
     // when using a TransOnlyGuard
     class Transaction {
@@ -526,10 +530,10 @@ namespace TSX {
             bool has_locked_;
 
         public:
-            Transaction(int &retries,TSX::SpinLock &global_lock, TSX::TSXStats &stats): 
+            Transaction(int &retries): 
             retries_(retries), 
-            lock_(global_lock), 
-            stats_(stats),
+            lock_(__internal__global_lock), 
+            stats_(__internal__trans_stats),
             has_locked_(false) {
                 if (retries == 0) {
                     lock_.lock();
@@ -566,6 +570,7 @@ namespace TSX {
             }
     };
 
+    thread_local Transaction* __internal__trans_pointer = nullptr;
 };
 
 
@@ -582,9 +587,12 @@ namespace TSX {
 
     // thread safe operation macro definitions
     #ifdef TM_EARLY_ABORT
-        #define TM_SAFE_OPERATION_START \
+        #define TM_SAFE_OPERATION_START(n_retries) \
         __internal__thread_transaction_success_flag__ = false;\
+        int __current__op__retries = n_retries; \
         while(!__internal__thread_transaction_success_flag__) { \
+            TSX::Transaction __trans_obj__(__current__op__retries);
+            TSX::__internal__trans_pointer = &__trans_obj__;
         try {\
 
         #define TM_SAFE_OPERATION_END \
@@ -594,12 +602,15 @@ namespace TSX {
         }
 
     #else
-        #define TM_SAFE_OPERATION_START \
+        #define TM_SAFE_OPERATION_START(n_retries) \
         __internal__thread_transaction_success_flag__ = false;\
-        while(!__internal__thread_transaction_success_flag__) \
+        int __current__op__retries = n_retries; \
+        while(!__internal__thread_transaction_success_flag__) {\
+            TSX::Transaction __trans_obj(__current__op__retries);\
+            TSX::__internal__trans_pointer = &__trans_obj;
 
 
-        #define TM_SAFE_OPERATION_END
+        #define TM_SAFE_OPERATION_END }
     #endif
 
 #endif

--- a/include/helper_data_structures.hpp
+++ b/include/helper_data_structures.hpp
@@ -115,6 +115,21 @@ struct NodeAndNextPointer {
     NodeAndNextPointer(){}
     NodeAndNextPointer(NodeType* node, int next_child):node(node), next_child(next_child){}
     NodeAndNextPointer(NodeAndNextPointer&& other): node(other.node), next_child(other.next_child) {}
+
+    NodeAndNextPointer(const NodeAndNextPointer& other): node(other.node), next_child(other.next_child) {}
+    
+    // NodeAndNextPointer& operator=(NodeAndNextPointer&& other) {
+    //     node = other.node;
+    //     next_child = other.next_child;
+    // }
+
+    NodeAndNextPointer& operator=(const NodeAndNextPointer other) {
+        node = other.node;
+        next_child = other.next_child;
+
+        return *this;
+    }
+
 };
 
 template <class NodeType, int CAP>
@@ -130,8 +145,8 @@ class TreePathStackWithIndex{
         };
 
         void move_to(TreePathStackWithIndex& other_stack) {
-            for (int i = 0; i < currentIndex; i++) {
-                other_stack.stack[i] = std::move(stack[i]);
+            for (int i = 0; i <= currentIndex; i++) {
+                other_stack.stack[i] = stack[i];
             }
             other_stack.currentIndex = currentIndex;
         }


### PR DESCRIPTION
### Concurrency bug
The path_changed() validation function contained a bug where
if the path to the connection point was empty, it would skip
checking that the root is in fact the connection point. It was fixed.

### Transaction Hidden
The user no longer needs to initialize the Transaction object explicitly. It is
hidden inside the macro.
